### PR TITLE
A minor fix to file path encoding error : Update __init__.py

### DIFF
--- a/kiui/__init__.py
+++ b/kiui/__init__.py
@@ -11,7 +11,7 @@ submodules = [m.strip('.py') for m in os.listdir(module_path) if not m.startswit
 
 # find out all function names without importing the module
 utils_path = os.path.join(module_path, 'utils.py')
-with open(utils_path) as f:
+with open(utils_path, encoding="UTF8") as f:
     utils_code = f.readlines()
 utils_funcnames = []
 for line in utils_code:


### PR DESCRIPTION
The kit runs perfectly on my system except a small issue. Works now with a line adding small clarification to text encoding. Hope it helps you as well.

Changes: 
Added failsafe to multilingual encoding error(e.g. cp949)